### PR TITLE
Example asm patch to load the hotest actor everywhere

### DIFF
--- a/asm_patches/includes/CreateHotestFunc.c
+++ b/asm_patches/includes/CreateHotestFunc.c
@@ -4,6 +4,16 @@ void CreateHotestFunc(){
      cXyz scale = {1.0f, 1.0f, 1.0f};
      cXyz position = {0.0f, 0.0f, 0.0f};;
      csXyz angle = {0.0f, 0.0f, 0.0f};
+     int *stageNo =(int *)0x803C53A4;
+     //int roomNo = dStage_roomControl_c__mStayNo;
+     static int has_run = 0;
+     if (*stageNo == 0){
+          if(!has_run){
+          fopAcM_create(0x00B5, 0, &position, dStage_roomControl_c__mStayNo, &angle, &scale, 0xFF, 0);
+          has_run = 1;
+          }
+     }
+     else{
      fopAcM_create(0x00B5, 0, &position, dStage_roomControl_c__mStayNo, &angle, &scale, 0xFF, 0);
+     }
 }
-

--- a/asm_patches/includes/CreateHotestFunc.c
+++ b/asm_patches/includes/CreateHotestFunc.c
@@ -1,19 +1,35 @@
 #include "../../vanilla_defines/ww_defines.h"
 
 void CreateHotestFunc(){
-     cXyz scale = {1.0f, 1.0f, 1.0f};
+     cXyz scale = {1.0f, 1.0f, 1.0f};                  // Initialize scale, position and angle
      cXyz position = {0.0f, 0.0f, 0.0f};;
      csXyz angle = {0.0f, 0.0f, 0.0f};
-     int *stageNo =(int *)0x803C53A4;
-     //int roomNo = dStage_roomControl_c__mStayNo;
-     static int has_run = 0;
-     if (*stageNo == 0){
-          if(!has_run){
-          fopAcM_create(0x00B5, 0, &position, dStage_roomControl_c__mStayNo, &angle, &scale, 0xFF, 0);
-          has_run = 1;
+     static byte sumCount = 0x00;                      // Initialize a counter for how many actors load from Fa.arc
+
+     for(int i=0; i<=63; i++){
+     byte *byte1 = (byte *)(0x803e0bc8 + i*0x24);      // List of loaded resource archives from res/Object starts at 0x803e0bc8
+     byte *byte2 = (byte *)(0x803e0bc9 + i*0x24);      // Every object takes 36 bytes (36=0x24)
+     byte *byte3 = (byte *)(0x803e0bca + i*0x24);      // The first seven bytes tell the resource name. In our case FA = 46 61 00 00 00 00 00
+     byte *byte4 = (byte *)(0x803e0bcb + i*0x24);      
+     byte *byte5 = (byte *)(0x803e0bcc + i*0x24);      // We iterate trough the list
+     byte *byte6 = (byte *)(0x803e0bcd + i*0x24);
+     byte *byte7 = (byte *)(0x803e0bce + i*0x24);
+     byte *count = (byte *)(0x803e0bd7 + i*0x24);      // The 15th and 16th bytes tell how many actors load from this resource. For us the 16th byte is enough.
+
+                                                       // If FA arc is loaded, and at least one actor loads from it, sum the amount of actors doing this.
+          if((*byte1 == 0x46 && *byte2 == 0x61 && *byte3 == 0x00 && *byte4 == 0x00 && *byte5 == 0x00 && *byte6 == 0x00 && *byte7 == 0x00) && (*count != 0x00)){
+               sumCount = sumCount + *count;
           }
+     
      }
+
+
+     if(sumCount == 0x00){                             // Create the hotest actor (0x00b5) only if no actor loads from Fa.arc
+          fopAcM_create(0x00B5, 0, &position, dStage_roomControl_c__mStayNo, &angle, &scale, 0xFF, 0);
+          //hasBeenCreated = false;
+     }
+
      else{
-     fopAcM_create(0x00B5, 0, &position, dStage_roomControl_c__mStayNo, &angle, &scale, 0xFF, 0);
+          sumCount = 0x00;                             // Set sumCount to zero for, so that the actor can be generated on room transitions
      }
 }

--- a/asm_patches/includes/CreateHotestFunc.c
+++ b/asm_patches/includes/CreateHotestFunc.c
@@ -1,0 +1,9 @@
+#include "../../vanilla_defines/ww_defines.h"
+
+void CreateHotestFunc(){
+     cXyz scale = {1.0f, 1.0f, 1.0f};
+     cXyz position = {0.0f, 0.0f, 0.0f};;
+     csXyz angle = {0.0f, 0.0f, 0.0f};
+     fopAcM_create(0x00B5, 0, &position, dStage_roomControl_c__mStayNo, &angle, &scale, 0xFF, 0);
+}
+

--- a/asm_patches/includes/spawn_hotest.asm
+++ b/asm_patches/includes/spawn_hotest.asm
@@ -1,0 +1,31 @@
+.open "sys/main.dol"
+ .org 0x80043238                 ; In dStage_dt_c_roomReLoader
+ bl CreateHotest
+
+ .org @NextFreeSpace
+ .global CreateHotest
+ CreateHotest:
+                                 ; Since we have subroutines, we need to store our link register
+ stwu sp, -0x10(sp)              ; Save the stack frame
+ mflr r0                         ; Move the LR into r0 
+ stw r0, 0x14(sp)                ; Store LR in the stack
+
+                                 ; First we call bl	0x80328F8C since we overwrote this call.
+ lis   r12, 0x8032               ; Load the upper 16 bits of the address 0x8032 into r12
+ ori   r12, r12, 0x8F8C          ; Load the lower 16 bits of the address 0x8F6C into r12
+ mtlr  r12                       ; Move the target address from r12 into the link register 
+ blrl                            ; Branch to the address in the link register and link back
+
+ bl CreateHotestFunc             ; We call our custom function stored in "includes/CreateHotestFunc.c"
+
+ lwz r0, 0x14(sp)                ; Restore LR from the stack
+ mtlr r0                         ; Move the value back into the LR
+ addi sp, sp, 0x10               ; Restore the stack frame
+ blr                             ; Return
+
+ .include "includes/CreateHotestFunc.c"
+.close
+
+
+
+


### PR DESCRIPTION
The patch hooks dStage_dt_c_roomReLoader to place the "hotest" blank test actor at (0,0,0) on room load, except if one exists already